### PR TITLE
Add "Back to Top" Links in README for Better Navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # 🌟 **GitHub Tracker** 🌟
+<!-- top -->
 
 **Track Activity of Users on GitHub**
 
@@ -145,3 +146,13 @@ spec_files: [
     <img src="https://contrib.rocks/image?repo=mehul-m-prajapati/github_tracker&&max=1000" />
   </a>
 </div>
+
+
+
+---
+
+<p align="center">
+  <a href="#top" style="font-size: 18px; padding: 8px 16px; display: inline-block; border: 1px solid #ccc; border-radius: 6px; text-decoration: none;">
+    ⬆️ Back to Top
+  </a>
+</p>


### PR DESCRIPTION
The current README.md is too long and contains multiple sections. Scrolling through it can be cumbersome, especially for new users or contributors accessing it on smaller screens.

💡 Proposed Solution
Add [🔝 Back to Top] links at the end of major sections in the README

Optionally add a top anchor like (though GitHub supports #readme by default)

Maintain consistent formatting across all sections

Issue number #139 