### PR TITLE
Feat: Added MetricCard component and updated routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import MetricCard from "./components/MetricCard";
 import Navbar from "./components/Navbar";
 import Footer from "./components/Footer";
 import ScrollProgressBar from './components/ScrollProgressBar';

--- a/src/Routes/Router.tsx
+++ b/src/Routes/Router.tsx
@@ -1,3 +1,5 @@
+
+import Metrics from "../components/MetricCard.tsx";
 import { Navigate, Route, Routes } from "react-router-dom";
 
 import Home from "../pages/Home/Home"; // Import the Home component
@@ -7,6 +9,7 @@ import Contributors from "../pages/Contributors/Contributors";
 import Signup from "../pages/Signup/Signup.tsx";
 import Login from "../pages/Login/Login.tsx";
 import UserProfile from "../pages/UserProfile/UserProfile.tsx";
+import MetricCard from "../components/MetricCard.tsx";
 
 const Router = () => {
   return (
@@ -20,6 +23,8 @@ const Router = () => {
       <Route path="/home" element={<Home />} />
       <Route path="/contributors" element={<Contributors />} />
       <Route path="/user/:username" element={<UserProfile />} />
+
+      <Route path="/metrics" element={<Metrics />} />
     </Routes>
   );
 };

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -1,0 +1,26 @@
+
+import React from "react";
+
+function MetricCard({ username="md-jasim123" }) {
+    const ProfileUrl = `https://metrics.lecoq.io/${username}`;
+    return (
+        <div className="flex justify-center mt-10">
+            <div className="bg-white shadow-md p-8 rounded-lg text-center">     
+            <h2 className="text-2xl font-semibold mb-4">GitHub Metric</h2>
+             <p className="mb-4">
+                Click the button below to view the Github metrics of <strong>{username}</strong>
+             </p>
+             <a 
+                href={ProfileUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+               >
+                View Metrics
+             </a>   
+        </div>
+        </div>
+    )
+}
+
+export default MetricCard;

--- a/src/page/Metrics/Metrics.tsx
+++ b/src/page/Metrics/Metrics.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import MetricCard from "../../components/MetricCard";
+
+const Metrics: React.FC = () => {
+    return (
+        <div className="mt-10 flex justify-center">
+            <MetricCard />
+        </div>
+    );
+
+};
+
+export default Metrics;


### PR DESCRIPTION
### Related Issue
- Closes: #50

---

### Description
Added MetricCard component to display GitHub metrics of the user using https://metrics.lecoq.io/<username> URL. It accepts a username as a prop.

---

### How Has This Been Tested?
Tested locally using `npm run dev`. Verified that the button correctly opens the metrics page in a new tab.

---

### Screenshots (if applicable)
_N/A_ (No UI changes requiring screenshots)

---

### Type of Change

- [ ] Bug fix  
- [x] New feature  
- [ ] Code style update  
- [ ] Breaking change  
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Metrics page accessible at the /metrics route.
  * Added a MetricCard component that displays a GitHub metric card for a specified username, including a link to view detailed metrics.

* **Navigation**
  * Updated routing to include the new Metrics page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->